### PR TITLE
meaningful error msg when invalid msg len

### DIFF
--- a/common/protocol.go
+++ b/common/protocol.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 )
 
 const PROTOCOL_HEADER int = 4
@@ -54,14 +55,12 @@ func ReadFromBuffer(buffer *bytes.Buffer) (string, error) {
 }
 
 func AppendToBuffer(msg string, buffer *bytes.Buffer) (*bytes.Buffer, error) {
+	if len(msg) > MESSAGE_MAX_SIZE {
+		return nil, fmt.Errorf("message length was %d, max size is: %d", len(msg), MESSAGE_MAX_SIZE)
+	}
 
 	if buffer == nil {
 		buffer = bytes.NewBuffer(make([]byte, 0))
-	}
-
-	msglength := len(msg)
-	if msglength > MESSAGE_MAX_SIZE {
-		return nil, errors.New("message too long")
 	}
 
 	header := make([]byte, PROTOCOL_HEADER)

--- a/common/protocol_test.go
+++ b/common/protocol_test.go
@@ -3,8 +3,26 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
+
+func TestErrWhenMsgLength(t *testing.T) {
+	b := make([]rune, MESSAGE_MAX_SIZE+1)
+	for i := range b {
+		b[i] = 'a'
+	}
+	invalidLengthMsg := string(b)
+
+	want := fmt.Sprintf("message length was %d, max size is: %d", MESSAGE_MAX_SIZE+1, MESSAGE_MAX_SIZE)
+	_, err := AppendToBuffer(invalidLengthMsg, nil)
+	if err == nil {
+		t.Fatalf("expected error not to be nil")
+	}
+	if want != err.Error() {
+		t.Fatalf("expected error '%s' but got %s", want, err)
+	}
+}
 
 // --- READ --------------------------------------------------------------------
 func Test_ReadMessageFromBuffer_OK(t *testing.T) {
@@ -165,8 +183,9 @@ func Test_AppendToBuffer_SizeLimit_Errors(t *testing.T) {
 		t.Fatal("expected error but got none")
 	}
 
-	if err.Error() != "message too long" {
-		t.Fatalf("expected message '%s' but got '%s' instead", msg, err.Error())
+	want := fmt.Sprintf("message length was %d, max size is: %d", len(longmessage), MESSAGE_MAX_SIZE)
+	if err.Error() != want {
+		t.Fatalf("expected message '%s' but got '%s' instead", want, err.Error())
 	}
 
 }


### PR DESCRIPTION
1) always meaningful error messages
2) check failure case first, avoid 1 allocation